### PR TITLE
Improvements to #kap 7 and #kap 8 reports and new #kap 9 report

### DIFF
--- a/inventory/kapsowar/Inventory Items Operations/InventoryItems_Distributed.jrxml
+++ b/inventory/kapsowar/Inventory Items Operations/InventoryItems_Distributed.jrxml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
-<!-- 2016-04-05T14:07:26 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="InventoryItemsDistributed" pageWidth="595" pageHeight="842" whenNoDataType="NoDataSection" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="d01934e8-0fb7-4c8f-9a89-b6bd526c395f">
+<!-- 2016-04-07T12:23:53 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="InventoryItems_Distributed" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="2411efa7-bbb4-43eb-94eb-402271379e8e">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
-	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="Kapsowar"/>
 	<style name="Table_TH" mode="Opaque" backcolor="#F0F8FF">
 		<box>
 			<pen lineWidth="0.5" lineColor="#000000"/>
@@ -32,10 +31,10 @@
 		</box>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style backcolor="#D0E1F2"/>
+			<style backcolor="#DAE3ED"/>
 		</conditionalStyle>
 	</style>
-	<subDataset name="DistributedInvData" uuid="c56c0f22-3e22-4d0e-9806-d1a4f465a68e">
+	<subDataset name="DistributedInventory" uuid="b8211bf9-3b4b-4d70-b1a1-dd5e5b84c882">
 		<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 		<property name="com.jaspersoft.studio.data.defaultdataadapter" value="Kapsowar"/>
 		<parameter name="beginDate" class="java.util.Date">
@@ -58,8 +57,8 @@
 			<![CDATA[SELECT
 CONCAT(patient_person_name.given_name, ' ', patient_person_name.family_name) as PatientName,
 inv_item.name as InventoryItemName, 
-COUNT(inv_trans.transaction_id) as NoOfTransactions, 
-ABS(inv_trans.quantity) as QuantityDistributed
+COUNT(inv_item.name) as NoOfTransactions, 
+SUM(ABS(inv_trans.quantity)) as QuantityDistributed
 FROM inv_transaction AS inv_trans
 	INNER JOIN inv_stock_operation inv_sto
 	ON inv_trans.operation_id = inv_sto.stock_operation_id
@@ -73,14 +72,14 @@ FROM inv_transaction AS inv_trans
     patient_person.person_id = patient_person_name.person_id AND
     patient_person_name.preferred = 1
 WHERE inv_sto.operation_type_id = 3 AND inv_sto.patient_id IS NOT NULL
-AND inv_trans.patient_id = $P{patientID} 
-AND (inv_trans.date_created BETWEEN  $P{beginDatePattern} AND  $P{endDatePattern} )
+AND inv_trans.patient_id = $P{patientID}   
+AND (inv_trans.date_created BETWEEN  $P{beginDatePattern} AND  $P{endDatePattern})
 GROUP BY inv_item.name;]]>
 		</queryString>
 		<field name="PatientName" class="java.lang.String"/>
 		<field name="InventoryItemName" class="java.lang.String"/>
 		<field name="NoOfTransactions" class="java.lang.Long"/>
-		<field name="QuantityDistributed" class="java.lang.Long"/>
+		<field name="QuantityDistributed" class="java.math.BigDecimal"/>
 	</subDataset>
 	<parameter name="beginDate" class="java.util.Date">
 		<parameterDescription><![CDATA[]]></parameterDescription>
@@ -105,9 +104,9 @@ GROUP BY inv_item.name;]]>
 		<band splitType="Stretch"/>
 	</background>
 	<title>
-		<band height="36" splitType="Stretch">
+		<band height="33" splitType="Stretch">
 			<staticText>
-				<reportElement x="0" y="0" width="575" height="32" uuid="c69cf57a-3805-40ff-b6d1-ac61f62e6884"/>
+				<reportElement x="0" y="0" width="575" height="32" uuid="ee4bb476-c5e4-4077-ab99-6277a2c81891"/>
 				<textElement textAlignment="Center" verticalAlignment="Middle">
 					<font size="24"/>
 				</textElement>
@@ -116,47 +115,24 @@ GROUP BY inv_item.name;]]>
 		</band>
 	</title>
 	<pageHeader>
-		<band height="33" splitType="Stretch">
+		<band height="31" splitType="Stretch">
 			<textField>
-				<reportElement x="0" y="0" width="575" height="25" uuid="91f01cba-b63b-4416-b07e-4e4eb50613ec"/>
-				<textElement>
+				<reportElement x="0" y="0" width="575" height="25" uuid="95add421-7eee-40e8-94bf-3bb31dcdb066"/>
+				<textElement textAlignment="Center">
 					<font size="12" isBold="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Inventory Item Distribution Report for " + new SimpleDateFormat("yyyy-MMM-dd").format($P{beginDate}) + " to " + new SimpleDateFormat("yyyy-MMM-dd").format($P{endDate})]]></textFieldExpression>
 			</textField>
 		</band>
 	</pageHeader>
-	<pageFooter>
-		<band height="29" splitType="Stretch">
-			<textField>
-				<reportElement x="0" y="6" width="369" height="16" uuid="72bfd8d1-f29e-4e91-ad01-f4877143609f"/>
-				<textElement textAlignment="Left">
-					<font isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Generated at " + new SimpleDateFormat("yyyy-dd-MM HH:mm").format(new Date())]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="494" y="5" width="61" height="20" uuid="b27a755d-fecd-4729-8e14-6b1b042c9e6a"/>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report">
-				<reportElement x="531" y="5" width="36" height="16" uuid="088857a9-f9c8-4e2f-beb8-5d75ee7c5b2d"/>
-				<textElement textAlignment="Right">
-					<font isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
-	</pageFooter>
-	<summary>
-		<band height="63" splitType="Stretch">
+	<detail>
+		<band height="91" splitType="Stretch">
 			<componentElement>
-				<reportElement x="0" y="0" width="555" height="60" uuid="d01ac313-42d9-485d-9870-69f82cca473b">
+				<reportElement x="40" y="0" width="470" height="90" uuid="eed41d65-6e4a-4d29-85dc-2b5d27c43286">
 					<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.VerticalRowLayout"/>
 				</reportElement>
 				<jr:table xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
-					<datasetRun subDataset="DistributedInvData" uuid="227ea83f-9be6-4a49-a306-5bc0d3084714">
+					<datasetRun subDataset="DistributedInventory" uuid="4cf4a0f8-6ed4-4ff6-be86-b31f0ef6bbd6">
 						<datasetParameter name="beginDate">
 							<datasetParameterExpression><![CDATA[new Date()]]></datasetParameterExpression>
 						</datasetParameter>
@@ -174,77 +150,86 @@ GROUP BY inv_item.name;]]>
 						</datasetParameter>
 						<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
 					</datasetRun>
-					<jr:column width="160" uuid="3227ebe4-3040-460b-b245-afe4689f3197">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column1"/>
-						<jr:columnHeader style="Table_CH" height="30">
-							<staticText>
-								<reportElement x="0" y="0" width="160" height="30" uuid="6a3408e1-8798-4add-a694-d942dac0e0cc"/>
-								<textElement textAlignment="Center" verticalAlignment="Middle">
+					<jr:column width="270" uuid="047e0972-10b4-448f-8758-43bfdde839dc">
+						<jr:tableHeader style="Table_TH" height="30">
+							<box>
+								<topPen lineWidth="0.0"/>
+								<leftPen lineWidth="0.0"/>
+								<bottomPen lineWidth="0.0"/>
+								<rightPen lineWidth="0.0"/>
+							</box>
+							<textField>
+								<reportElement x="0" y="0" width="270" height="30" uuid="55d86313-de5a-4ff8-b04b-5da10163c82d"/>
+								<textElement textAlignment="Left" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
-								<text><![CDATA[Patient Name]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:detailCell style="Table_TD" height="30">
-							<textField>
-								<reportElement x="0" y="0" width="160" height="30" uuid="684f9f8c-a9e4-4e6c-9006-576d71d3ee2b"/>
-								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{PatientName}]]></textFieldExpression>
 							</textField>
-						</jr:detailCell>
-					</jr:column>
-					<jr:column width="250" uuid="a6f96b02-16cd-4c69-8e4a-7801aab19d92">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column2"/>
+						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="250" height="30" uuid="a94836e9-f36c-4047-91a1-4bba1723a184"/>
+								<reportElement x="0" y="0" width="270" height="30" uuid="d74b15e7-4b12-48ba-9d6f-2694e36d220c"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
-								<text><![CDATA[Inventory Item Name]]></text>
+								<text><![CDATA[Item Name]]></text>
 							</staticText>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="250" height="30" uuid="a3efce08-2224-40b3-b813-07ddfc0a848b"/>
+								<reportElement x="0" y="0" width="270" height="30" uuid="e165bca9-d382-4d98-96f9-e82f0ed294f2"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{InventoryItemName}]]></textFieldExpression>
 							</textField>
 						</jr:detailCell>
 					</jr:column>
-					<jr:column width="80" uuid="55d7fdb0-ec7b-4eed-b46b-db334a991dad">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column3"/>
+					<jr:column width="110" uuid="338dc8a2-84a7-4783-891d-1148527cf3a6">
+						<jr:tableHeader style="Table_TH" height="30">
+							<box>
+								<topPen lineWidth="0.0"/>
+								<leftPen lineWidth="0.0"/>
+								<bottomPen lineWidth="0.0"/>
+								<rightPen lineWidth="0.0"/>
+							</box>
+						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="80" height="30" uuid="b4f7c9dd-ca91-4304-b05b-9934b914f74f"/>
+								<reportElement x="0" y="0" width="110" height="30" uuid="56e79653-7ade-43d3-91fc-bb8ab567b5c2"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
-								<text><![CDATA[No Of Transactions]]></text>
+								<text><![CDATA[Number of Transactions]]></text>
 							</staticText>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="80" height="30" uuid="fd5169d0-2e54-4b89-8354-f88a2e90a9cc"/>
+								<reportElement x="0" y="0" width="110" height="30" uuid="0f04656c-0c81-4211-a405-ca89541f973f"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{NoOfTransactions}]]></textFieldExpression>
 							</textField>
 						</jr:detailCell>
 					</jr:column>
-					<jr:column width="70" uuid="456b938f-dd4d-4cfe-8237-23953a7bf0d6">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column4"/>
+					<jr:column width="90" uuid="74093e4c-cea9-4a05-bf05-790739435855">
+						<jr:tableHeader style="Table_TH" height="30">
+							<box>
+								<topPen lineWidth="0.0"/>
+								<leftPen lineWidth="0.0"/>
+								<bottomPen lineWidth="0.0"/>
+								<rightPen lineWidth="0.0"/>
+							</box>
+						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="70" height="30" uuid="9f5b8d39-d73e-4de3-992b-276b8810c511"/>
+								<reportElement x="0" y="0" width="90" height="30" uuid="e08ef8f2-b83c-4816-92ab-af19f6fb84a1"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
-								<text><![CDATA[Quantity Distributed]]></text>
+								<text><![CDATA[Amount Distributed]]></text>
 							</staticText>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="70" height="30" uuid="6506cc1d-b7d3-4578-9ff6-142d04c49df1"/>
+								<reportElement x="0" y="0" width="90" height="30" uuid="1f0d6878-2dc4-4dd4-aece-81ea0c2161b3"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{QuantityDistributed}]]></textFieldExpression>
 							</textField>
@@ -253,11 +238,34 @@ GROUP BY inv_item.name;]]>
 				</jr:table>
 			</componentElement>
 		</band>
-	</summary>
+	</detail>
+	<pageFooter>
+		<band height="34" splitType="Stretch">
+			<textField>
+				<reportElement x="0" y="6" width="369" height="16" uuid="f6e16d1e-88b1-4524-ba23-c7586489b881"/>
+				<textElement textAlignment="Left">
+					<font isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Generated at " + new SimpleDateFormat("yyyy-dd-MM HH:mm").format(new Date())]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="494" y="5" width="61" height="20" uuid="48c93d36-425a-4dc2-a3a8-c33572d22dc9"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="531" y="5" width="36" height="16" uuid="cdf01323-e3db-4deb-87a1-5394b840c957"/>
+				<textElement textAlignment="Right">
+					<font isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
 	<noData>
-		<band height="27">
+		<band height="22">
 			<staticText>
-				<reportElement x="0" y="5" width="306" height="16" uuid="264ddf73-6fe8-4e8f-8dc3-f9eb2462e7c4"/>
+				<reportElement x="0" y="5" width="306" height="16" uuid="632a1189-a83b-4ccb-9b5f-c99488e1c87b"/>
 				<textElement textAlignment="Left">
 					<font isBold="false" isItalic="true"/>
 				</textElement>

--- a/inventory/kapsowar/Inventory Items Operations/InventoryItems_Transfered.jrxml
+++ b/inventory/kapsowar/Inventory Items Operations/InventoryItems_Transfered.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
-<!-- 2016-04-06T15:20:52 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="InventoryItems_Transfered" pageWidth="595" pageHeight="842" whenNoDataType="NoDataSection" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="ebad2bae-c2b4-4a63-b343-eb2286f3b5cd">
+<!-- 2016-04-07T14:24:59 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="InventoryItems_Transfered" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="79a5f0d0-19ad-4022-a658-dcd2caeb7caa">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<style name="Table_TH" mode="Opaque" backcolor="#F0F8FF">
 		<box>
@@ -31,10 +31,10 @@
 		</box>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style backcolor="#DFE8F2"/>
+			<style backcolor="#E1E9F2"/>
 		</conditionalStyle>
 	</style>
-	<subDataset name="InventoryTransfered" uuid="020aec32-b773-4380-840c-ec8c0daf6f21">
+	<subDataset name="Inventory items Transfered" uuid="92c3dfd0-e5f6-4b2c-88bf-c30ff366fabc">
 		<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 		<property name="com.jaspersoft.studio.data.defaultdataadapter" value="Kapsowar"/>
 		<parameter name="beginDate" class="java.util.Date">
@@ -50,8 +50,10 @@
 		<parameter name="endDatePattern" class="java.lang.String" isForPrompting="false">
 			<defaultValueExpression><![CDATA[new SimpleDateFormat("yyyy-MM-dd").format($P{endDate})]]></defaultValueExpression>
 		</parameter>
-		<parameter name="sourceStockroomID" class="java.lang.Integer"/>
-		<parameter name="destinationStockroomID" class="java.lang.Integer"/>
+		<parameter name="firstStockroomID" class="java.lang.Integer">
+			<parameterDescription><![CDATA[]]></parameterDescription>
+		</parameter>
+		<parameter name="latterStockroomID" class="java.lang.Integer"/>
 		<queryString>
 			<![CDATA[SELECT
 inv_item.name as InventoryItemName, 
@@ -73,8 +75,8 @@ FROM inv_transaction AS inv_trans
     AND inv_sto.status = 'COMPLETED'
     
 WHERE inv_sto.operation_type_id = 6
-AND (inv_sto.source_id =  $P{sourceStockroomID} AND inv_sto.destination_id =  $P{destinationStockroomID} 
-AND inv_trans.stockroom_id =  $P{destinationStockroomID})
+AND (inv_sto.source_id = $P{firstStockroomID}   AND inv_sto.destination_id = $P{latterStockroomID}  
+AND inv_trans.stockroom_id = $P{latterStockroomID}  )
 AND (inv_trans.date_created BETWEEN  $P{beginDatePattern} AND  $P{endDatePattern})
 GROUP BY inv_item.name;]]>
 		</queryString>
@@ -97,25 +99,27 @@ GROUP BY inv_item.name;]]>
 	<parameter name="endDatePattern" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[new SimpleDateFormat("yyyy-MM-dd").format($P{endDate})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="sourceStockroomID" class="java.lang.Integer"/>
-	<parameter name="destinationStockroomID" class="java.lang.Integer"/>
+	<parameter name="firstStockroomID" class="java.lang.Integer">
+		<parameterDescription><![CDATA[]]></parameterDescription>
+	</parameter>
+	<parameter name="latterStockroomID" class="java.lang.Integer"/>
 	<queryString>
-		<![CDATA[SELECT 1]]>
+		<![CDATA[SELECT 1;]]>
 	</queryString>
 	<background>
 		<band splitType="Stretch"/>
 	</background>
 	<title>
-		<band height="51" splitType="Stretch">
+		<band height="54" splitType="Stretch">
 			<staticText>
-				<reportElement x="0" y="0" width="575" height="32" uuid="3d394feb-d515-4d7c-83d4-3a2040a277bd"/>
+				<reportElement x="0" y="0" width="575" height="32" uuid="33d91bbb-0dfd-43ac-98e3-99ac79c1e9ac"/>
 				<textElement textAlignment="Center" verticalAlignment="Middle">
 					<font size="24"/>
 				</textElement>
 				<text><![CDATA[Kapsowar Hospital]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="0" y="30" width="575" height="20" uuid="3dc4c0a4-46eb-4589-855b-a24d8fc412b6"/>
+				<reportElement x="0" y="32" width="575" height="20" uuid="88420910-629f-4e8b-844e-12f02e244933"/>
 				<textElement textAlignment="Center">
 					<font size="14"/>
 				</textElement>
@@ -124,9 +128,9 @@ GROUP BY inv_item.name;]]>
 		</band>
 	</title>
 	<pageHeader>
-		<band height="19" splitType="Stretch">
+		<band height="26" splitType="Stretch">
 			<textField>
-				<reportElement x="0" y="0" width="401" height="18" uuid="3b747c90-5a38-4331-a60f-4e4980afead3"/>
+				<reportElement x="40" y="-2" width="401" height="18" uuid="9f085a7b-1465-4fee-a521-7a528b9b6787"/>
 				<textElement>
 					<font size="12" isBold="false"/>
 				</textElement>
@@ -134,37 +138,14 @@ GROUP BY inv_item.name;]]>
 			</textField>
 		</band>
 	</pageHeader>
-	<pageFooter>
-		<band height="30" splitType="Stretch">
-			<textField>
-				<reportElement x="0" y="6" width="369" height="16" uuid="fb92e32b-c9b8-4019-9bbd-6013b4783e08"/>
-				<textElement textAlignment="Left">
-					<font isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Generated at " + new SimpleDateFormat("yyyy-dd-MM HH:mm").format(new Date())]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="494" y="5" width="61" height="20" uuid="1de969c9-8f25-45d9-9b7f-1ea7ce672852"/>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report">
-				<reportElement x="531" y="5" width="36" height="16" uuid="452d0b65-2fac-4fc8-9f5c-ea87e217babb"/>
-				<textElement textAlignment="Right">
-					<font isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
-	</pageFooter>
-	<summary>
-		<band height="100" splitType="Stretch">
+	<detail>
+		<band height="91" splitType="Stretch">
 			<componentElement>
-				<reportElement x="40" y="10" width="460" height="90" uuid="ffb1050c-17e5-4359-ba51-30e0753f9cae">
+				<reportElement x="40" y="0" width="500" height="90" uuid="8333c7b1-2174-49d5-92cc-f2e67dafba3b">
 					<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.VerticalRowLayout"/>
 				</reportElement>
 				<jr:table xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
-					<datasetRun subDataset="InventoryTransfered" uuid="9498f21d-4ac3-444f-9f7c-01975143f39f">
+					<datasetRun subDataset="Inventory items Transfered" uuid="68621d21-2542-4320-ab3f-4fc704795651">
 						<datasetParameter name="beginDate">
 							<datasetParameterExpression><![CDATA[new Date()]]></datasetParameterExpression>
 						</datasetParameter>
@@ -177,16 +158,15 @@ GROUP BY inv_item.name;]]>
 						<datasetParameter name="endDatePattern">
 							<datasetParameterExpression><![CDATA[new SimpleDateFormat("yyyy-MM-dd").format($P{endDate})]]></datasetParameterExpression>
 						</datasetParameter>
-						<datasetParameter name="sourceStockroomID">
-							<datasetParameterExpression><![CDATA[$P{sourceStockroomID}]]></datasetParameterExpression>
+						<datasetParameter name="firstStockroomID">
+							<datasetParameterExpression><![CDATA[$P{firstStockroomID}]]></datasetParameterExpression>
 						</datasetParameter>
-						<datasetParameter name="destinationStockroomID">
-							<datasetParameterExpression><![CDATA[$P{destinationStockroomID}]]></datasetParameterExpression>
+						<datasetParameter name="latterStockroomID">
+							<datasetParameterExpression><![CDATA[$P{latterStockroomID}]]></datasetParameterExpression>
 						</datasetParameter>
 						<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
 					</datasetRun>
-					<jr:column width="240" uuid="c9b6b162-2c97-4c17-aa07-9c9820783b91">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column1"/>
+					<jr:column width="240" uuid="f7be4d40-0611-4a1f-ae26-6378bb6b338b">
 						<jr:tableHeader style="Table_TH" height="30">
 							<box>
 								<topPen lineWidth="0.0"/>
@@ -195,7 +175,7 @@ GROUP BY inv_item.name;]]>
 								<rightPen lineWidth="0.0"/>
 							</box>
 							<textField>
-								<reportElement x="0" y="0" width="240" height="30" uuid="e2d96efb-00b5-4f1e-aa9b-e02183c09bde"/>
+								<reportElement x="0" y="0" width="240" height="30" uuid="648abfe0-61fa-498d-a053-8cca2bc6f34e"/>
 								<textElement textAlignment="Right" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
@@ -204,7 +184,7 @@ GROUP BY inv_item.name;]]>
 						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="240" height="30" uuid="51e39022-826c-42bb-8890-0a988652d1a9"/>
+								<reportElement x="0" y="0" width="240" height="30" uuid="593f1aa0-eedf-4277-aa57-5b7034102159"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
@@ -213,14 +193,13 @@ GROUP BY inv_item.name;]]>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="240" height="30" uuid="b9067da6-75bd-4487-84fd-001bbbe669df"/>
+								<reportElement x="0" y="0" width="240" height="30" uuid="21dfcee6-f5b1-4682-a26f-26b8b530ea3a"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{InventoryItemName}]]></textFieldExpression>
 							</textField>
 						</jr:detailCell>
 					</jr:column>
-					<jr:column width="120" uuid="a9fed329-2e78-45de-99f5-8d7cec3ad92b">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column2"/>
+					<jr:column width="140" uuid="a786d1d4-92dc-4ea2-99ec-874e6bbe5bd3">
 						<jr:tableHeader style="Table_TH" height="30">
 							<box>
 								<topPen lineWidth="0.0"/>
@@ -229,8 +208,8 @@ GROUP BY inv_item.name;]]>
 								<rightPen lineWidth="0.0"/>
 							</box>
 							<textField>
-								<reportElement x="0" y="0" width="120" height="30" uuid="5f702b32-a62c-494e-a1b5-a412160eabfb"/>
-								<textElement verticalAlignment="Middle">
+								<reportElement x="0" y="0" width="140" height="30" uuid="98cc40da-b67e-4559-acec-dbc26bf12d64"/>
+								<textElement textAlignment="Left" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
 								<textFieldExpression><![CDATA[" To: " + $F{DestinationStockroom}]]></textFieldExpression>
@@ -238,7 +217,7 @@ GROUP BY inv_item.name;]]>
 						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="120" height="30" uuid="bba250d1-db41-439c-b334-522d78ee6666"/>
+								<reportElement x="0" y="0" width="140" height="30" uuid="d9145824-4e0b-4041-b83a-6b01bb53344f"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
@@ -247,14 +226,13 @@ GROUP BY inv_item.name;]]>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="120" height="30" uuid="7acf1e02-a3cb-4651-97ad-3562aa6e942d"/>
+								<reportElement x="0" y="0" width="140" height="30" uuid="a2ba6589-bcdd-46c8-90c9-9046a97d3b18"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{NoOfTransactions}]]></textFieldExpression>
 							</textField>
 						</jr:detailCell>
 					</jr:column>
-					<jr:column width="102" uuid="3907bad1-94e9-407e-a339-c6ce42385111">
-						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column3"/>
+					<jr:column width="120" uuid="94cebffc-3883-4438-a4c4-9544425da1b5">
 						<jr:tableHeader style="Table_TH" height="30">
 							<box>
 								<topPen lineWidth="0.0"/>
@@ -265,7 +243,7 @@ GROUP BY inv_item.name;]]>
 						</jr:tableHeader>
 						<jr:columnHeader style="Table_CH" height="30">
 							<staticText>
-								<reportElement x="0" y="0" width="102" height="30" uuid="0cc8333c-24e4-469d-800a-454c76c0f199"/>
+								<reportElement x="0" y="0" width="120" height="30" uuid="0e9e191c-3785-419f-a9ca-6a87e8cc4811"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font isBold="true"/>
 								</textElement>
@@ -274,7 +252,7 @@ GROUP BY inv_item.name;]]>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
-								<reportElement x="0" y="0" width="102" height="30" uuid="f33a6261-264e-44b4-bc45-5991e5709fd2"/>
+								<reportElement x="0" y="0" width="120" height="30" uuid="8326358f-8e4e-47cf-a2a0-84460d6f2011"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle"/>
 								<textFieldExpression><![CDATA[$F{AmountTransfered}]]></textFieldExpression>
 							</textField>
@@ -283,11 +261,34 @@ GROUP BY inv_item.name;]]>
 				</jr:table>
 			</componentElement>
 		</band>
-	</summary>
+	</detail>
+	<pageFooter>
+		<band height="30" splitType="Stretch">
+			<textField>
+				<reportElement x="0" y="6" width="369" height="16" uuid="647d6c2a-a6df-4189-b877-f29adf467262"/>
+				<textElement textAlignment="Left">
+					<font isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Generated at " + new SimpleDateFormat("yyyy-dd-MM HH:mm").format(new Date())]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="494" y="5" width="61" height="20" uuid="3ea0dfe4-04d3-4691-bcc7-c494b0d46f5b"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="531" y="5" width="36" height="16" uuid="da665ed0-cc9f-4d78-95a0-17dadcbe2624"/>
+				<textElement textAlignment="Right">
+					<font isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
 	<noData>
-		<band height="24">
+		<band height="31">
 			<staticText>
-				<reportElement x="0" y="5" width="306" height="16" uuid="bb6616ce-bbd4-4799-9dde-31f261ef326c"/>
+				<reportElement x="0" y="5" width="306" height="16" uuid="6ce6a811-96b2-4a66-ba32-b07120038ecd"/>
 				<textElement textAlignment="Left">
 					<font isBold="false" isItalic="true"/>
 				</textElement>

--- a/inventory/kapsowar/Stockroom/Stockroom_withInvItemsPercentageUsed.jrxml
+++ b/inventory/kapsowar/Stockroom/Stockroom_withInvItemsPercentageUsed.jrxml
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2016-04-07T14:54:26 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Stockroom_withInvItemsPercentageUsed" language="groovy" pageWidth="595" pageHeight="842" whenNoDataType="NoDataSection" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="0b72be3f-d755-462a-8a67-0282dc90d574">
+	<property name="ireport.zoom" value="2.0"/>
+	<property name="ireport.x" value="0"/>
+	<property name="ireport.y" value="0"/>
+	<style name="table">
+		<box>
+			<pen lineWidth="1.0" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_TH" mode="Opaque" backcolor="#F0F8FF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_CH" mode="Opaque" backcolor="#BFE1FF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_TD" mode="Opaque" backcolor="#FFFFFF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table 1">
+		<box>
+			<pen lineWidth="1.0" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table 1_TH" mode="Opaque" backcolor="#F0F8FF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table 1_CH" mode="Opaque" backcolor="#BFE1FF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table 1_TD" mode="Opaque" backcolor="#FFFFFF">
+		<box>
+			<pen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<subDataset name="Stockroom Item Stock" uuid="4ddff745-c801-490f-9e16-520912866ea0">
+		<property name="com.jaspersoft.studio.data.defaultdataadapter" value="Kapsowar"/>
+		<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+		<parameter name="beginDate" class="java.util.Date">
+			<defaultValueExpression><![CDATA[]]></defaultValueExpression>
+		</parameter>
+		<parameter name="endDate" class="java.util.Date">
+			<defaultValueExpression><![CDATA[]]></defaultValueExpression>
+		</parameter>
+		<parameter name="stockroomId" class="java.lang.Integer">
+			<defaultValueExpression><![CDATA[]]></defaultValueExpression>
+		</parameter>
+		<queryString>
+			<![CDATA[SELECT
+i.name item_name,
+IFNULL(begin_stock.qty, 0) beginning,
+IFNULL(incoming_stock.qty, 0) incoming,
+IFNULL(outgoing_stock.qty, 0) outgoing,
+IFNULL(end_stock.qty, 0) ending,
+(SELECT (ABS(outgoing)/(incoming+beginning))*100) as percentUsed
+FROM
+inv_stockroom sr INNER JOIN
+(SELECT stockroom_id, item_id, SUM(trans.quantity) AS qty
+FROM inv_transaction trans INNER JOIN inv_stock_operation op1 ON
+trans.operation_id = op1.stock_operation_id
+WHERE stockroom_id = $P{stockroomId} AND op1.operation_date <= CONCAT($P{endDate} ,' ' ,'23:59:59')
+GROUP BY stockroom_id, item_id) end_stock ON
+sr.stockroom_id = end_stock.stockroom_id
+LEFT OUTER JOIN
+		(SELECT stockroom_id, item_id, SUM(trans.quantity) AS qty
+		 FROM inv_transaction trans INNER JOIN inv_stock_operation op2 ON
+			trans.operation_id = op2.stock_operation_id
+		 WHERE stockroom_id = $P{stockroomId} AND op2.operation_date  <= $P{beginDate}
+		 GROUP BY stockroom_id, item_id) begin_stock ON
+			sr.stockroom_id = begin_stock.stockroom_id AND
+			end_stock.item_id = begin_stock.item_id
+	LEFT OUTER JOIN
+		(SELECT stockroom_id, item_id, SUM(trans.quantity) AS qty
+		 FROM inv_transaction trans INNER JOIN inv_stock_operation op3 ON
+			trans.operation_id = op3.stock_operation_id
+		 WHERE stockroom_id = $P{stockroomId} AND op3.operation_date > $P{beginDate} AND op3.operation_date <= CONCAT($P{endDate} ,' ' ,'23:59:59') AND quantity > 0
+		 GROUP BY stockroom_id, item_id) incoming_stock ON
+			sr.stockroom_id = incoming_stock.stockroom_id AND
+			end_stock.item_id = incoming_stock.item_id
+	LEFT OUTER JOIN
+		(SELECT stockroom_id, item_id, SUM(trans.quantity) AS qty
+		 FROM inv_transaction trans INNER JOIN inv_stock_operation op4 ON
+			trans.operation_id = op4.stock_operation_id
+		 WHERE stockroom_id = $P{stockroomId} AND op4.operation_date > $P{beginDate} AND op4.operation_date <= CONCAT($P{endDate} ,' ' ,'23:59:59') AND quantity <= 0
+		 GROUP BY stockroom_id, item_id) outgoing_stock ON
+			sr.stockroom_id = outgoing_stock.stockroom_id AND
+			end_stock.item_id = outgoing_stock.item_id
+	INNER JOIN inv_item i ON
+		end_stock.item_id = i.item_id
+WHERE
+	sr.stockroom_id = $P{stockroomId}
+ORDER BY percentUsed DESC;]]>
+		</queryString>
+		<field name="item_name" class="java.lang.String"/>
+		<field name="beginning" class="java.math.BigDecimal"/>
+		<field name="incoming" class="java.math.BigDecimal"/>
+		<field name="outgoing" class="java.math.BigDecimal"/>
+		<field name="ending" class="java.math.BigDecimal"/>
+		<field name="percentUsed" class="java.math.BigDecimal"/>
+	</subDataset>
+	<parameter name="beginDate" class="java.util.Date"/>
+	<parameter name="endDate" class="java.util.Date"/>
+	<parameter name="stockroomId" class="java.lang.Integer"/>
+	<queryString>
+		<![CDATA[SELECT name from inv_stockroom where stockroom_id = $P{stockroomId}]]>
+	</queryString>
+	<field name="name" class="java.lang.String">
+		<fieldDescription><![CDATA[]]></fieldDescription>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<title>
+		<band height="35" splitType="Stretch">
+			<staticText>
+				<reportElement x="0" y="0" width="555" height="32" uuid="a334a322-2426-4915-ac87-2fc6a0d5d573"/>
+				<textElement textAlignment="Center">
+					<font size="24"/>
+				</textElement>
+				<text><![CDATA[AIC Kapsowar Hospital]]></text>
+			</staticText>
+		</band>
+	</title>
+	<pageHeader>
+		<band height="27" splitType="Stretch">
+			<textField>
+				<reportElement x="0" y="0" width="555" height="25" uuid="833f8d94-32f0-4b30-9c56-995682b3e0bf"/>
+				<textElement>
+					<font size="12" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Stockroom Report for " + $F{name} + " from " + new SimpleDateFormat("yyyy-MMM-dd").format($P{beginDate}) + " to " + new SimpleDateFormat("yyyy-MMM-dd").format($P{endDate})]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageHeader>
+	<detail>
+		<band height="50">
+			<componentElement>
+				<reportElement key="table 1" style="table 1" x="0" y="0" width="555" height="50" uuid="f7c68e6d-0720-43f6-8820-6b8549999ed1"/>
+				<jr:table xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" whenNoDataType="AllSectionsNoDetail">
+					<datasetRun subDataset="Stockroom Item Stock" uuid="a0054c7b-98c5-4457-969f-24732885f3ec">
+						<datasetParameter name="beginDate">
+							<datasetParameterExpression><![CDATA[$P{beginDate}]]></datasetParameterExpression>
+						</datasetParameter>
+						<datasetParameter name="endDate">
+							<datasetParameterExpression><![CDATA[$P{endDate}]]></datasetParameterExpression>
+						</datasetParameter>
+						<datasetParameter name="stockroomId">
+							<datasetParameterExpression><![CDATA[$P{stockroomId}]]></datasetParameterExpression>
+						</datasetParameter>
+						<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+					</datasetRun>
+					<jr:column width="230" uuid="b58cb061-182d-4902-848e-c1f76933c76c">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column1"/>
+						<jr:columnHeader style="table 1_CH" height="17" rowSpan="1">
+							<staticText>
+								<reportElement x="0" y="0" width="90" height="17" uuid="aaa1b9e9-0f6d-448e-a6be-eb96b5581819"/>
+								<textElement verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph leftIndent="2"/>
+								</textElement>
+								<text><![CDATA[Name]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15" rowSpan="1">
+							<textField isStretchWithOverflow="true">
+								<reportElement x="0" y="0" width="230" height="15" uuid="5787820a-0aaf-40bf-bd59-0afac03294e6"/>
+								<textElement verticalAlignment="Middle">
+									<paragraph leftIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{item_name}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+					<jr:column width="70" uuid="c535b35f-570e-4e9c-b6eb-624615030595">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column2"/>
+						<jr:columnHeader style="table 1_CH" height="17" rowSpan="1">
+							<staticText>
+								<reportElement x="0" y="0" width="70" height="17" uuid="c3199e2a-044a-4370-9b7a-f18aa0274ce2"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<text><![CDATA[Opening]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15" rowSpan="1">
+							<textField pattern="#,##0" isBlankWhenNull="false">
+								<reportElement x="0" y="0" width="70" height="15" uuid="3dc6affc-89e0-41e4-979d-3b53a941835f"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{beginning}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+					<jr:column width="70" uuid="ff03cf08-e870-430b-b9db-03cf49c11d05">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column3"/>
+						<jr:columnHeader style="table 1_CH" height="17" rowSpan="1">
+							<staticText>
+								<reportElement x="0" y="0" width="70" height="17" uuid="cd657892-e6d4-4f20-b755-7ff48c6b952c"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<text><![CDATA[Incoming]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15" rowSpan="1">
+							<textField pattern="#,##0">
+								<reportElement x="0" y="0" width="70" height="15" uuid="d9076fca-7cc4-4fee-bb8e-9f240316cf33"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{incoming}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+					<jr:column width="60" uuid="3fdfb74b-9dd8-4d4f-b2d6-33b04de016a9">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column4"/>
+						<jr:columnHeader style="table 1_CH" height="17" rowSpan="1">
+							<staticText>
+								<reportElement x="0" y="0" width="60" height="17" uuid="15920a5d-475b-438d-ae9f-c1276fad699d"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<text><![CDATA[Outgoing]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15" rowSpan="1">
+							<textField pattern="#,##0">
+								<reportElement x="0" y="0" width="60" height="15" uuid="8201ed26-d116-4e56-a534-90fdfead5063"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{outgoing}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+					<jr:column width="50" uuid="4428dc26-e90a-4b52-8fc1-b10a0f3605ff">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column5"/>
+						<jr:columnHeader style="table 1_CH" height="17" rowSpan="1">
+							<staticText>
+								<reportElement x="0" y="0" width="50" height="17" uuid="77fe4e92-43ee-46e6-b94d-a7116428bddb"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<text><![CDATA[Closing]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15" rowSpan="1">
+							<textField pattern="#,##0">
+								<reportElement x="0" y="0" width="50" height="15" uuid="ec7637f5-a2d6-4f94-97df-af4057997140"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{ending}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+					<jr:column width="75" uuid="01558dcf-b8d9-4b1e-9761-d5bebd59131a">
+						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column6"/>
+						<jr:columnHeader style="table 1_CH" height="17">
+							<staticText>
+								<reportElement x="0" y="0" width="75" height="17" uuid="5c99fb6a-08ca-4ba0-9129-015852922d10"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<font isBold="true"/>
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<text><![CDATA[Percentage]]></text>
+							</staticText>
+						</jr:columnHeader>
+						<jr:detailCell style="table 1_TD" height="15">
+							<textField pattern="#,##0">
+								<reportElement x="0" y="0" width="75" height="15" uuid="57ab7cbb-63e5-45b7-943b-2b7119539fbc"/>
+								<textElement textAlignment="Right" verticalAlignment="Middle">
+									<paragraph rightIndent="2"/>
+								</textElement>
+								<textFieldExpression><![CDATA[$F{percentUsed}]]></textFieldExpression>
+							</textField>
+						</jr:detailCell>
+					</jr:column>
+				</jr:table>
+			</componentElement>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="20" splitType="Stretch">
+			<textField>
+				<reportElement x="0" y="0" width="379" height="20" uuid="6c430987-cd11-40be-bd9d-2077e233745f"/>
+				<textFieldExpression><![CDATA["Generated at " + new SimpleDateFormat("yyyy-MMM-dd HH:mm").format(new Date())]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="522" y="0" width="33" height="20" uuid="7a9813a0-b37a-4dcb-a749-b1725b610579"/>
+				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="431" y="0" width="87" height="20" uuid="f96d7780-6357-4924-b519-27f72a508d29"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<noData>
+		<band height="20">
+			<staticText>
+				<reportElement x="0" y="0" width="306" height="16" uuid="e8da193c-2a64-44be-96ca-7416132f7400"/>
+				<textElement textAlignment="Left">
+					<font isBold="false" isItalic="true"/>
+				</textElement>
+				<text><![CDATA[No data was found to display on the report.]]></text>
+			</staticText>
+		</band>
+	</noData>
+</jasperReport>


### PR DESCRIPTION
Made changes to the query for Kap7 to get the correct number of transactions. Made changes to the 2 Jasper reports, moving the Table element to the detail band from the summary band since this was causing a report null error when loading the reports to openmrs.
Added a new stockroom report, kap9, that features a new PercentageUsed Field for tracking Inventory Items usage over time.
